### PR TITLE
implement TraceUtils.newLogger()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/common",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/common",
-      "version": "2.11.0",
+      "version": "2.11.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "async": "^2.6.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/common",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "MOST Web Framework Codename Blueshift - Common Module",
   "main": "index.js",
   "types": "index.d.ts",

--- a/spec/TraceUtils.spec.ts
+++ b/spec/TraceUtils.spec.ts
@@ -1,0 +1,10 @@
+import { TraceUtils } from "../utils";
+
+describe('ApplicationService', () => {
+    it('should create new logger', () => {
+        const logger = TraceUtils.newLogger();
+        expect(logger).toBeTruthy();
+        logger.level('verbose');
+        logger.verbose('test verbose');
+    });
+});

--- a/spec/TraceUtils.spec.ts
+++ b/spec/TraceUtils.spec.ts
@@ -1,10 +1,15 @@
-import { TraceUtils } from "../utils";
+import { TraceLogger, TraceUtils } from "../utils";
 
 describe('ApplicationService', () => {
     it('should create new logger', () => {
         const logger = TraceUtils.newLogger();
         expect(logger).toBeTruthy();
         logger.level('verbose');
+        const spy = spyOn(console, 'log');
         logger.verbose('test verbose');
+        expect(spy).toHaveBeenCalled();
+        spy.calls.reset();
+        TraceUtils.verbose('test verbose');
+        expect(spy).not.toHaveBeenCalled();
     });
 });

--- a/utils.d.ts
+++ b/utils.d.ts
@@ -276,7 +276,7 @@ export declare class TraceLogger implements ITraceLogger {
     verbose(...data: any[]): void;
     debug(...data: any[]): void;
     private timestamp();
-    private write(level, text);
+    protected write(level, text);
 }
 export declare class TraceUtils {
 

--- a/utils.d.ts
+++ b/utils.d.ts
@@ -256,6 +256,10 @@ export interface ITraceLogger {
      * @param {...*} data
      */
     debug(...data: any[]): any;
+    /**
+     * @param {...*} data
+     */
+    verbose(...data: any[]): any;
 }
 export interface ITraceLoggerOptions {
     colors: boolean;
@@ -310,6 +314,12 @@ export declare class TraceUtils {
      * @param {...*} data
      */
     static debug(...data: any[]): void;
+    /**
+     *
+     * @static
+     * @param {...*} data
+     */
+    static verbose(...data: any[]): void;
 }
 
 /**

--- a/utils.d.ts
+++ b/utils.d.ts
@@ -279,6 +279,9 @@ export declare class TraceUtils {
     static level(level: string): void;
 
     static useLogger(logger: ITraceLogger): void;
+
+    static newLogger(): ITraceLogger;
+
     /**
      * @static
      * @param {...*} data

--- a/utils.js
+++ b/utils.js
@@ -585,7 +585,11 @@ function TraceUtils() {
     };
 
     TraceUtils.newLogger = function() {
-        return Object.create(TraceUtils[loggerProperty]);
+        const newLogger = Object.create(TraceUtils[loggerProperty]);
+        // copy options
+        const logger = TraceUtils[loggerProperty];
+        newLogger.options = Object.assign({}, logger.options);
+        return newLogger;
     };
 
     TraceUtils.level = function(level) {

--- a/utils.js
+++ b/utils.js
@@ -258,7 +258,7 @@ LangUtils.parseForm = function (form, options) {
         return result;
     var keys = Object.keys(form);
     keys.forEach(function(key) {
-        if (form.hasOwnProperty(key))
+        if (Object.prototype.hasOwnProperty.call(form, key))
         {
             LangUtils.extend(result, key, form[key], options)
         }
@@ -584,6 +584,10 @@ function TraceUtils() {
         TraceUtils[loggerProperty] = logger;
     };
 
+    TraceUtils.newLogger = function() {
+        return Object.create(TraceUtils[loggerProperty]);
+    };
+
     TraceUtils.level = function(level) {
         TraceUtils[loggerProperty].level(level);
     };
@@ -835,11 +839,11 @@ function timestamp() {
  */
 function writeError(level, err) {
 
-    var keys = _.filter(_.keys(err), function(x) {
-        return err.hasOwnProperty(x) && x!=='message' && typeof err[x] !== 'undefined' && err[x] != null;
+    var keys = _.filter(_.keys(err), function(key) {
+        return Object.prototype.hasOwnProperty.call(err, key) && key!=='message' && typeof err[key] !== 'undefined' && err[key] != null;
     });
     if (err instanceof Error) {
-        if (err.hasOwnProperty('stack')) {
+        if (Object.prototype.hasOwnProperty.call(err, 'stack')) {
             this.write(level, err.stack);
         }
         else {
@@ -874,7 +878,7 @@ function TraceLogger(options) {
     if (typeof options !== "undefined" && options !== null ) {
         this.options = options;
         //validate logging level
-        Args.check(LogLevels.hasOwnProperty(this.options.level), "Invalid logging level. Expected error, warn, info, verbose or debug.");
+        Args.check(Object.prototype.hasOwnProperty.call(LogLevels, this.options.level), "Invalid logging level. Expected error, warn, info, verbose or debug.");
     }
 }
 
@@ -883,7 +887,7 @@ function TraceLogger(options) {
  * @returns {*}
  */
 TraceLogger.prototype.level = function(level) {
-    Args.check(LogLevels.hasOwnProperty(level), "Invalid logging level. Expected error, warn, info, verbose or debug.");
+    Args.check(Object.prototype.hasOwnProperty.call(LogLevels, level), "Invalid logging level. Expected error, warn, info, verbose or debug.");
     this.options.level = level;
     return this;
 };


### PR DESCRIPTION
This PR implement newLogger() method for creating a new instance of the current TraceLogger class.